### PR TITLE
Use individual columns over CSV in by=

### DIFF
--- a/R/sample.R
+++ b/R/sample.R
@@ -28,8 +28,6 @@
 #' iris %>% sample_n_dt(2,by = "Species")
 #' iris %>% sample_frac_dt(.1,by = "Species")
 #'
-#' mtcars %>% sample_n_dt(1,by = "cyl,vs")
-#' # equals to
 #' mtcars %>% sample_n_dt(1,by = c("cyl","vs"))
 
 

--- a/R/summarise_dt.R
+++ b/R/summarise_dt.R
@@ -28,7 +28,7 @@
 #' iris %>% summarise_vars(1:4,min)
 #'
 #' iris %>% summarise_vars(is.numeric,min,by ="Species")
-#' mtcars %>% summarise_vars(is.numeric,mean,by = "vs,am")
+#' mtcars %>% summarise_vars(is.numeric,mean,by = c("vs", "am"))
 #'
 #' # use multiple functions on multiple columns
 #' iris %>%

--- a/man/sample.Rd
+++ b/man/sample.Rd
@@ -50,8 +50,6 @@ sample_dt(mtcars,prop = 0.1)
 iris \%>\% sample_n_dt(2,by = "Species")
 iris \%>\% sample_frac_dt(.1,by = "Species")
 
-mtcars \%>\% sample_n_dt(1,by = "cyl,vs")
-# equals to
 mtcars \%>\% sample_n_dt(1,by = c("cyl","vs"))
 }
 \seealso{

--- a/man/summarise_dt.Rd
+++ b/man/summarise_dt.Rd
@@ -60,7 +60,7 @@ iris \%>\% summarise_vars(-is.factor,min)
 iris \%>\% summarise_vars(1:4,min)
 
 iris \%>\% summarise_vars(is.numeric,min,by ="Species")
-mtcars \%>\% summarise_vars(is.numeric,mean,by = "vs,am")
+mtcars \%>\% summarise_vars(is.numeric,mean,by = c("vs", "am"))
 
 # use multiple functions on multiple columns
 iris \%>\%

--- a/tests/testthat/test-count_dt.R
+++ b/tests/testthat/test-count_dt.R
@@ -14,7 +14,7 @@ test_that("count", {
 
   expect_equal(
     mtcars %>% count_dt(cyl,vs),
-    mt[,.(n = .N),by = "cyl,vs"][order(-n)]
+    mt[,.(n = .N),by = c("cyl","vs")][order(-n)]
   )
 
   expect_equal(

--- a/tests/testthat/test-group_dt.R
+++ b/tests/testthat/test-group_dt.R
@@ -62,7 +62,7 @@ test_that("use group by in tidyfst",{
       group_exe_dt(
         summarise_dt(mpg_sum = sum(mpg))
       ),
-    mt[,.(mpg_sum=sum(mpg)),keyby="cyl,am"],
+    mt[,.(mpg_sum=sum(mpg)),keyby=c("cyl","am")],
     check.attributes = FALSE
   )
   expect_equal(

--- a/vignettes/benchmark.Rmd
+++ b/vignettes/benchmark.Rmd
@@ -69,7 +69,7 @@ bench::mark(
                   by = .(id4,id5)],
   tidyfst = DT %>%
     summarise_dt(
-      by = "id4,id5",
+      by = c("id4", "id5"),
       median_v3 = median(v3),
       sd_v3 = sd(v3)
     ),


### PR DESCRIPTION
data.table is considering deprecating this approach to specifying `by=`, namely, as a comma-separated string of columns, because of the inconsistency it induces.

Please follow up in https://github.com/Rdatatable/data.table/issues/4357 if you have further input about this plan.